### PR TITLE
Header style

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -5,7 +5,7 @@ export default function Header(props) {
     <div className="header">
       <h1>ProtoCards</h1>
       <p>Welcome <span>{props.userName}</span>!</p>
-      <p>You've completed <span>{props.completion}</span> out of 30 questions!</p>
+      <p><span>{props.completion}</span> out of <span>30</span> questions complete!</p>
     </div>
     )
 }

--- a/src/style/_Header.scss
+++ b/src/style/_Header.scss
@@ -4,9 +4,7 @@
   @include position(fixed, 0, 0, initial, 0);
   @include flex(center, row, center);
   h1 {
-    font-family: 'Pacifico';
-    font-size: 46px;
-    text-shadow: 3px 3px black;
+    @include customText(46px, 400, 'Pacifico', $pink, center, 3px);
   }
   p {
     font-size: 20px;

--- a/src/style/_Header.scss
+++ b/src/style/_Header.scss
@@ -7,8 +7,7 @@
     @include customText(46px, 400, 'Pacifico', $pink, center, 3px);
   }
   p {
-    font-size: 20px;
-    text-shadow: 2px 2px black;
+    @include customText(20px, initial, 'Open Sans', $pink, center, 2px);
   }
   p:nth-child(2) {
     @include position(absolute, 0, 20px, initial, initial);
@@ -17,8 +16,7 @@
     @include position(absolute, initial, 20px, 0, initial);
   }
   span {
-    color: #fff;
-    font-weight: 700;
+    @include customText(20px, 700, inherit, #fff, initial, 2px);
   }
 }
 


### PR DESCRIPTION
### Changes made:
- Header message 'Youve completed _ out of 30 questions!' has been refactored 
to '_ out of 30 questions complete!'
- Title 'ProtoCards' has changed font-weight to be more readable

#### Before:
<img width="844" alt="screen shot 2019-02-25 at 7 55 08 pm" src="https://user-images.githubusercontent.com/44077214/53384216-598e6700-3937-11e9-9430-018dca711166.png">

#### After:
<img width="844" alt="screen shot 2019-02-25 at 7 54 37 pm" src="https://user-images.githubusercontent.com/44077214/53384217-5bf0c100-3937-11e9-859f-5478f4603ac9.png">
